### PR TITLE
Divide download and compress

### DIFF
--- a/src/components/LoadInfo.tsx
+++ b/src/components/LoadInfo.tsx
@@ -10,7 +10,7 @@ export const LoadInfo = ({filesCount, onClearFiles}: LoadInfoProps) => {
   if (filesCount === 0) return null
   return (
     <div className="success-file">
-      <p>{filesCount} file(s) selected</p>
+      <p>{filesCount} file{ filesCount > 1 && 's'} selected</p>
       <button
         onClick={onClearFiles}
         className="danger"

--- a/src/components/ResizedImageItem.css
+++ b/src/components/ResizedImageItem.css
@@ -1,0 +1,30 @@
+li.resized-item {
+  align-items: center;
+  background-color: var(--color-background-lighter);
+  border-radius: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 1rem;
+
+  header.item {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    justify-content: center;
+    align-items: center;
+
+    svg {
+      width: 2.5rem;
+      aspect-ratio: 1;
+      margin: 0;
+    }
+
+    p {
+      margin: 0;
+      font-size: 1.125rem;
+      text-align: center;
+    }
+  }
+}

--- a/src/components/ResizedImagesList.css
+++ b/src/components/ResizedImagesList.css
@@ -1,0 +1,56 @@
+div.resized-section {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  justify-content: start;
+  width: 100%;
+
+  header {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    align-content: center;
+    justify-content: center;
+
+    h2 {
+      margin: 0;
+      text-align: center;
+    }
+
+    div.action-buttons {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      justify-content: center;
+    }
+  }
+
+  ul {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+    gap: 1.5rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+  }
+}
+
+@media screen and (min-width: 800px) {
+  div.resized-section {
+    header {
+      flex-direction: row;
+      justify-content: space-between;
+
+      h2 {
+        text-align: start;
+      }
+
+      div.action-buttons {
+        flex-direction: row;
+        justify-content: end;
+        align-items: center;
+      }
+    }
+  }
+}

--- a/src/components/ResizedImagesList.tsx
+++ b/src/components/ResizedImagesList.tsx
@@ -1,0 +1,45 @@
+import { ResizedImageItem } from "./RezisedImageItem"
+
+import { AnchorObject } from "../types"
+import './ResizedImagesList.css'
+
+type ResizedImagesListProps = {
+  anchorObjects: AnchorObject[]
+  onDownloadAll: () => void
+  onClear: () => void
+}
+
+export const ResizedImagesList = ({ anchorObjects, onDownloadAll, onClear }: ResizedImagesListProps) => {
+  return (
+    <div className="resized-section">
+      <header>
+        <h2><span>{anchorObjects.length}</span> resized file{ anchorObjects.length > 1 && 's'}</h2>
+          <div className="action-buttons">
+            {
+              anchorObjects.length > 1 && (
+                <button
+                  className="button primary"
+                  onClick={onDownloadAll}
+                >
+                  Download All
+                </button>
+              )
+            }
+            <button
+              className="button secondary"
+              onClick={onClear}
+            >
+              Clear and upload again
+            </button>
+          </div>
+      </header>
+      <ul>
+        {anchorObjects.map((anchorObject, index) => {
+          return (
+            <ResizedImageItem key={index} anchorObject={anchorObject} />
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/RezisedImageItem.tsx
+++ b/src/components/RezisedImageItem.tsx
@@ -1,0 +1,28 @@
+import { ImageIcon } from "./Icons/Image"
+
+import { AnchorObject } from "../types"
+import './ResizedImageItem.css'
+
+type ResizedImageItemProps = {
+  anchorObject: AnchorObject
+}
+
+export const ResizedImageItem = ({ anchorObject }:ResizedImageItemProps) => {
+  const { url, name } = anchorObject
+  return (
+    <li className="resized-item">
+      <header className="item">
+        <ImageIcon fillColor='rgb(115 115 115)'/>
+        <p>{name}</p>
+      </header>
+      <a
+        key={name}
+        className="button secondary small"
+        href={url}
+        download={name}
+      >
+        Download
+      </a>
+    </li>
+  )
+}

--- a/src/helpers/resizeFiles.ts
+++ b/src/helpers/resizeFiles.ts
@@ -1,0 +1,38 @@
+import JSZip from 'jszip'
+import { saveAs } from 'file-saver'
+import { FileWithBlob } from "../screens/ResizeScreen"
+
+import { AnchorObject } from '../types'
+
+export const getFailedImages = (resizedImages: PromiseSettledResult<FileWithBlob>[]) => {
+  return resizedImages.filter((result) => result.status === 'rejected')
+}
+
+export const getSuccessImages = (resizedImages: PromiseSettledResult<FileWithBlob>[]): FileWithBlob[] => {
+  const converted = resizedImages
+    .filter((result) => result.status === 'fulfilled')
+    .map((result) => (result.status === 'fulfilled' ? result.value : null))
+    .filter((value) => value !== null) as FileWithBlob[]
+  return converted
+}
+
+export const createDowndloadZip = (files: AnchorObject[], fileName: string) => {
+  const zip = new JSZip();
+  files.forEach((file) => {
+    const { blob, name } = file
+    zip.file(name, blob)
+  })
+
+  // Generate the zip file and download it
+  zip.generateAsync({ type: 'blob' }).then((content) => {
+    saveAs(content, fileName);
+  });
+}
+
+export const getImagesAsAnchor = (files: FileWithBlob[]) => {
+  return files.map((file) => {
+    const { blob, name } = file
+    const url = URL.createObjectURL(blob)
+    return { url, name, blob }
+  })
+}

--- a/src/screens/ResizeScreen.tsx
+++ b/src/screens/ResizeScreen.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import DragAndDrop from '../components/DragAndDrop'
 import RangeSlider from '../components/RangeSlider'
 import { ResizeNav } from '../components/ReziseNav'
@@ -6,47 +6,51 @@ import { FileList } from '../components/FileList'
 import { Loader } from '../components/Loader'
 import { LoadInfo } from '../components/LoadInfo'
 import { SectionContainer } from '../components/SectionContainer'
-import JSZip from 'jszip'
-import { saveAs } from 'file-saver'
+import { ResizedImagesList } from '../components/ResizedImagesList'
+import { createDowndloadZip, getFailedImages, getImagesAsAnchor, getSuccessImages } from '../helpers/resizeFiles'
 
+import { AnchorObject, ResizeState } from '../types'
 import './ResizeScreen.css'
 
-interface FileWithBlob {
+export interface FileWithBlob {
   blob: Blob
   name: string
 }
 
 export const ResizeScreen = () => {
   const [files, setFiles] = useState<File[]>([])
+  const [phase, setPhase] = useState<ResizeState>(ResizeState.TO_LOAD)
   const [imageQuality, setImageQuality] = useState<number>(100)
   const [imageSize, setImageSize] = useState<number>(100)
-  const [isCompressing, setIsCompressing] = useState<boolean>(false)
+  const [anchorObjects, setAnchorObjects] = useState<AnchorObject[]>([])
+
+  useEffect(() => {
+    if (files.length > 0) {
+      setPhase(ResizeState.LOADED)
+    }
+  }, [files])
 
   const handleResize = async () => {
     if (imageQuality === 100 && imageSize === 100) return
 
-    setIsCompressing(true)
-    const zip = new JSZip();
+    setPhase(ResizeState.COMPRESSING)
 
     const resizePromises = files.map((file) => resize(file))
     const resizedImages = await Promise.allSettled(resizePromises)
 
-    resizedImages.forEach((result) => {
-      if (result.status === 'fulfilled') {
-        const { blob, name } = result.value
-        zip.file(name, blob)
-      } else {
-        console.error('Error resizing image', result.reason)
-      }
-    })
+    const failedImages = getFailedImages(resizedImages)
 
-    // Generate the zip file and download it
-    zip.generateAsync({ type: 'blob' }).then((content) => {
-      saveAs(content, 'resized_images.zip');
-    });
+    if (failedImages.length === files.length) {
+      console.error('All images failed to resize')
+      setPhase(ResizeState.LOADED)
+      return
+    }
+
+    const successImages = getSuccessImages(resizedImages)
+    setAnchorObjects(getImagesAsAnchor(successImages))
 
     setFiles([])
-    setIsCompressing(false)
+    setPhase(ResizeState.COMPRESSED)
   }
 
   const resize = (file: File): Promise<FileWithBlob> => {
@@ -63,8 +67,7 @@ export const ResizeScreen = () => {
           ctx.drawImage(image, 0, 0, canvas.width, canvas.height)
           canvas.toBlob((blob) => {
             if (blob) {
-              const fileName = `${file.name.split('.')[0]}_resized.jpg`; // Create a custom file name
-              resolve({ blob, name: fileName });
+              resolve({ blob, name: file.name });
             } else {
               reject({error: 'Error creating blob', name: file.name})
             }
@@ -79,11 +82,21 @@ export const ResizeScreen = () => {
     })
   }
 
-  if (isCompressing) {
+  const handleOnDownloadAll = () => {
+    createDowndloadZip(anchorObjects, 'resized_images.zip')
+  }
+
+
+  const handleOnClear = () => {
+    setAnchorObjects([])
+    setPhase(ResizeState.TO_LOAD)
+  }
+
+  if (phase === ResizeState.COMPRESSING) {
     return (
       <div className="compressing">
         <Loader />
-        <p>Compressing</p>
+        <p>Resizing</p>
       </div>
     )
   }
@@ -92,38 +105,53 @@ export const ResizeScreen = () => {
     <>
       <ResizeNav />
       <main>
-        <SectionContainer>
-          <DragAndDrop onFilesSelected={setFiles} files={files} />
-          <LoadInfo filesCount={files.length} onClearFiles={() => setFiles([])} />
-          { files.length > 0 && (
-            <>
-              <div className="upload-settings">
-                <RangeSlider
-                  label="Image Quality"
-                  min={10}
-                  max={100}
-                  step={10}
-                  initialValue={imageQuality}
-                  onChange={(newValue) => setImageQuality(newValue)}
-                />
-                <RangeSlider
-                  label="Image Size"
-                  min={10}
-                  max={100}
-                  step={10}
-                  initialValue={imageSize} onChange={(newValue) => setImageSize(newValue)}
-                />
-              </div>
-              <button className="primary bold large" onClick={handleResize}>
-                Resize and Download
-              </button>
-            </>
-          )}
-        </SectionContainer>
         {
-          files.length > 0 && (
+          (phase === ResizeState.TO_LOAD || phase === ResizeState.LOADED) && (
+            <SectionContainer>
+              <DragAndDrop onFilesSelected={setFiles} files={files} />
+              <LoadInfo filesCount={files.length} onClearFiles={() => setFiles([])} />
+              { files.length > 0 && phase === ResizeState.LOADED && (
+                <>
+                  <div className="upload-settings">
+                    <RangeSlider
+                      label="Image Quality"
+                      min={10}
+                      max={100}
+                      step={10}
+                      initialValue={imageQuality}
+                      onChange={(newValue) => setImageQuality(newValue)}
+                    />
+                    <RangeSlider
+                      label="Image Size"
+                      min={10}
+                      max={100}
+                      step={10}
+                      initialValue={imageSize} onChange={(newValue) => setImageSize(newValue)}
+                    />
+                  </div>
+                  <button className="primary bold large" onClick={handleResize}>
+                    Resize Images
+                  </button>
+                </>
+              )}
+            </SectionContainer>
+          )
+        }
+        {
+          files.length > 0 && phase === ResizeState.LOADED && (
             <SectionContainer>
               <FileList files={files} onRemoveFile={(index) => setFiles(files.filter((_, i) => i !== index))} />
+            </SectionContainer>
+          )
+        }
+        {
+          anchorObjects.length > 0 && phase === ResizeState.COMPRESSED && (
+            <SectionContainer>
+              <ResizedImagesList
+                anchorObjects={anchorObjects}
+                onDownloadAll={handleOnDownloadAll}
+                onClear={handleOnClear}
+              />
             </SectionContainer>
           )
         }

--- a/src/screens/ResizeScreen.tsx
+++ b/src/screens/ResizeScreen.tsx
@@ -23,16 +23,18 @@ export const ResizeScreen = () => {
   const [imageQuality, setImageQuality] = useState<number>(100)
   const [imageSize, setImageSize] = useState<number>(100)
   const [anchorObjects, setAnchorObjects] = useState<AnchorObject[]>([])
+  const [progress, setProgress] = useState<number>(0)
+  const [progressConstant, setProgressConstant] = useState<number>(0)
 
   useEffect(() => {
     if (files.length > 0) {
       setPhase(ResizeState.LOADED)
+      setProgressConstant(Math.floor(80 / files.length))
     }
   }, [files])
 
   const handleResize = async () => {
     if (imageQuality === 100 && imageSize === 100) return
-
     setPhase(ResizeState.COMPRESSING)
 
     const resizePromises = files.map((file) => resize(file))
@@ -45,12 +47,14 @@ export const ResizeScreen = () => {
       setPhase(ResizeState.LOADED)
       return
     }
-
+    setProgress(90)
     const successImages = getSuccessImages(resizedImages)
     setAnchorObjects(getImagesAsAnchor(successImages))
+    setProgress(100)
 
     setFiles([])
     setPhase(ResizeState.COMPRESSED)
+    setProgress(0)
   }
 
   const resize = (file: File): Promise<FileWithBlob> => {
@@ -75,6 +79,7 @@ export const ResizeScreen = () => {
         }else{
           reject({error: 'Error resizing image', name: file.name})
         }
+        setProgress((prev) => prev + progressConstant)
       }
       image.onerror = () => {
         reject({error: 'Error loading image', name: file.name})
@@ -96,6 +101,7 @@ export const ResizeScreen = () => {
     return (
       <div className="compressing">
         <Loader />
+        <h2>{progress}%</h2>
         <p>Resizing</p>
       </div>
     )

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,12 @@
+export type AnchorObject = {
+  url: string
+  name: string
+  blob: Blob
+}
+
+export enum ResizeState {
+  TO_LOAD = 'TO_LOAD',
+  LOADED = 'LOADED',
+  COMPRESSING = 'COMPRESSING',
+  COMPRESSED = 'COMPRESSED',
+}


### PR DESCRIPTION
Divide the process of resize and download to resize and then download.
To achieve this, a new section is created to list the resized images and allow to download each one separately, and include a button to download all as a zip.

- Add progress state of resizing to let visualize the progress of compressing the images.