### PR TITLE
Implement web worker for image resizing

### DIFF
--- a/src/components/ProgressLoading.css
+++ b/src/components/ProgressLoading.css
@@ -1,0 +1,17 @@
+div.compressing {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: 100vh;
+  align-items: center;
+  justify-content: center;
+
+  h2 {
+    margin: 0;
+  }
+
+  p {
+    font-weight: bold;
+    margin: 0;
+  }
+}

--- a/src/components/ProgressLoading.tsx
+++ b/src/components/ProgressLoading.tsx
@@ -1,0 +1,16 @@
+import { Loader } from "./Loader"
+
+import './ProgressLoading.css'
+
+type ProgressLoadingProps = {
+  progress: number
+}
+export const ProgressLoading = ({ progress }: ProgressLoadingProps) => {
+  return (
+    <div className="compressing">
+      <Loader />
+      <h2>{progress.toFixed(1)}%</h2>
+      <p>Resizing...</p>
+    </div>
+  )
+}

--- a/src/helpers/resizeFiles.ts
+++ b/src/helpers/resizeFiles.ts
@@ -3,6 +3,7 @@ import { saveAs } from 'file-saver'
 import { FileWithBlob } from "../screens/ResizeScreen"
 
 import { AnchorObject } from '../types'
+import { getErrorMessage } from './utils'
 
 export const getFailedImages = (resizedImages: PromiseSettledResult<FileWithBlob>[]) => {
   return resizedImages.filter((result) => result.status === 'rejected')
@@ -52,7 +53,8 @@ export const resizeImage = async (file: File, imageQuality: number, imageSize: n
     offScreenCanvas.convertToBlob({ type: 'image/jpeg', quality: imageQuality / 100 }).then(blob => {
       resolve({ blob, name: file.name });
     }).catch(err => {
-      reject(new Error('Error creating blob'));
+      const message = getErrorMessage(err);
+      reject(new Error(message));
     });
   });
 };

--- a/src/helpers/resizeFiles.ts
+++ b/src/helpers/resizeFiles.ts
@@ -29,7 +29,7 @@ export const createDowndloadZip = (files: AnchorObject[], fileName: string) => {
   });
 }
 
-export const getImagesAsAnchor = (files: FileWithBlob[]) => {
+export const getImagesAsAnchor = (files: FileWithBlob[]): AnchorObject[] => {
   return files.map((file) => {
     const { blob, name } = file
     const url = URL.createObjectURL(blob)

--- a/src/helpers/resizeFiles.ts
+++ b/src/helpers/resizeFiles.ts
@@ -36,3 +36,25 @@ export const getImagesAsAnchor = (files: FileWithBlob[]) => {
     return { url, name, blob }
   })
 }
+
+export const resizeImage = async (file: File, imageQuality: number, imageSize: number): Promise<FileWithBlob> => {
+  const imageBitmap = await createImageBitmap(file);
+  const offScreenCanvas = new OffscreenCanvas(imageBitmap.width * (imageSize / 100), imageBitmap.height * (imageSize / 100));
+  const ctx = offScreenCanvas.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('Error resizing image');
+  }
+
+  ctx.drawImage(imageBitmap, 0, 0, offScreenCanvas.width, offScreenCanvas.height);
+
+  return new Promise<{ blob: Blob; name: string }>((resolve, reject) => {
+    offScreenCanvas.convertToBlob({ type: 'image/jpeg', quality: imageQuality / 100 }).then(blob => {
+      resolve({ blob, name: file.name });
+    }).catch(err => {
+      reject(new Error('Error creating blob'));
+    });
+  });
+};
+
+

--- a/src/helpers/resizeFiles.ts
+++ b/src/helpers/resizeFiles.ts
@@ -1,8 +1,7 @@
 import JSZip from 'jszip'
 import { saveAs } from 'file-saver'
-import { FileWithBlob } from "../screens/ResizeScreen"
 
-import { AnchorObject } from '../types'
+import { AnchorObject, FileWithBlob } from '../types'
 import { getErrorMessage } from './utils'
 
 export const getFailedImages = (resizedImages: PromiseSettledResult<FileWithBlob>[]) => {

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -1,0 +1,4 @@
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return JSON.stringify(error)
+}

--- a/src/hooks/useResizeImagesWithWorker.tsx
+++ b/src/hooks/useResizeImagesWithWorker.tsx
@@ -1,0 +1,49 @@
+import { FileWithBlob } from "../types"
+import { ErrorWithMessage } from "../types"
+
+type UseResizeImagesWithWorkerProps = {
+  worker: Worker
+  setProgress: React.Dispatch<React.SetStateAction<number>>
+  files: File[]
+  progressConstant: number
+}
+
+export const useResizeImagesWithWorker = ({
+  worker,
+  setProgress,
+  files,
+  progressConstant
+}: UseResizeImagesWithWorkerProps) => {
+  const startResize = async ( imageQuality: number, imageSize: number) => {
+    const resizedImages: FileWithBlob[] = []
+
+    for (const file of files) {
+      const resizedImage = await resizeImageWithWorker(file, imageQuality, imageSize)
+      if ('error' in resizedImage) {
+        console.error(`Error resizing image ${file.name}: ${resizedImage.error}`)
+      } else {
+        resizedImages.push(resizedImage)
+      }
+      setProgress((prev) => prev + progressConstant)
+    }
+
+    return resizedImages
+  }
+
+  const resizeImageWithWorker = (file: File, imageQuality: number, imageSize: number): Promise<FileWithBlob | ErrorWithMessage> => {
+    return new Promise((resolve) => {
+      const { port1, port2 } = new MessageChannel()
+
+      port2.onmessage = (event: MessageEvent<FileWithBlob | ErrorWithMessage>) => {
+        resolve(event.data)
+        port2.close()
+      }
+
+      worker.postMessage({ port: port1, file, imageQuality, imageSize }, [port1])
+    })
+  }
+
+  return {
+    startResize
+  }
+}

--- a/src/hooks/useResizeImagesWithWorker.tsx
+++ b/src/hooks/useResizeImagesWithWorker.tsx
@@ -15,6 +15,10 @@ export const useResizeImagesWithWorker = ({
   progressConstant
 }: UseResizeImagesWithWorkerProps) => {
   const startResize = async ( imageQuality: number, imageSize: number) => {
+    if (!window.Worker) {
+      console.error('Web Workers are not supported in this browser')
+      return []
+    }
     const resizedImages: FileWithBlob[] = []
 
     for (const file of files) {

--- a/src/screens/ResizeScreen.css
+++ b/src/screens/ResizeScreen.css
@@ -26,21 +26,6 @@ div.upload-settings {
   width: 100%;
 }
 
-div.compressing {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  height: 100vh;
-  align-items: center;
-  justify-content: center;
-
-  p {
-    font-size: 1.5rem;
-    font-weight: bold;
-    margin: 0;
-  }
-}
-
 @media screen and (width > 600px) {
   main {
     div.upload-settings {

--- a/src/screens/ResizeScreen.tsx
+++ b/src/screens/ResizeScreen.tsx
@@ -9,7 +9,7 @@ import { SectionContainer } from '../components/SectionContainer'
 import { ResizedImagesList } from '../components/ResizedImagesList'
 import { createDowndloadZip, getImagesAsAnchor } from '../helpers/resizeFiles'
 
-import { AnchorObject, ResizeState } from '../types'
+import { AnchorObject, ErrorWithMessage, ResizeState } from '../types'
 import './ResizeScreen.css'
 
 export interface FileWithBlob {
@@ -47,7 +47,7 @@ export const ResizeScreen = () => {
 
     for (const file of files) {
       const resizedImage = await resizeImageWithWorker(file, imageQuality, imageSize)
-      if (resizedImage.error) {
+      if ('error' in resizedImage) {
         console.error(`Error resizing image ${file.name}: ${resizedImage.error}`)
       } else {
         resizedImages.push(resizedImage)
@@ -66,11 +66,11 @@ export const ResizeScreen = () => {
     }
   }
 
-  const resizeImageWithWorker = (file: File, imageQuality: number, imageSize: number): Promise<FileWithBlob> => {
+  const resizeImageWithWorker = (file: File, imageQuality: number, imageSize: number): Promise<FileWithBlob | ErrorWithMessage> => {
     return new Promise((resolve) => {
       const { port1, port2 } = new MessageChannel()
 
-      port2.onmessage = (event) => {
+      port2.onmessage = (event: MessageEvent<FileWithBlob | ErrorWithMessage>) => {
         resolve(event.data)
         port2.close()
       }

--- a/src/screens/ResizeScreen.tsx
+++ b/src/screens/ResizeScreen.tsx
@@ -3,8 +3,8 @@ import DragAndDrop from '../components/DragAndDrop'
 import RangeSlider from '../components/RangeSlider'
 import { ResizeNav } from '../components/ReziseNav'
 import { FileList } from '../components/FileList'
-import { Loader } from '../components/Loader'
 import { LoadInfo } from '../components/LoadInfo'
+import { ProgressLoading } from '../components/ProgressLoading'
 import { SectionContainer } from '../components/SectionContainer'
 import { ResizedImagesList } from '../components/ResizedImagesList'
 import { useResizeImagesWithWorker } from '../hooks/useResizeImagesWithWorker'
@@ -12,8 +12,6 @@ import { createDowndloadZip, getImagesAsAnchor } from '../helpers/resizeFiles';
 
 import { AnchorObject, FileWithBlob, ResizeState } from '../types'
 import './ResizeScreen.css'
-
-
 
 // Importar el Worker
 import ImageWorker from '../webworkers/imageWorker?worker'
@@ -56,6 +54,8 @@ export const ResizeScreen = () => {
     setProgress(90)
     setAnchorObjects(getImagesAsAnchor(resizedImages))
     setProgress(100)
+    if ( anchorObjects.length === 0 ) return setPhase(ResizeState.TO_LOAD)
+
     setFiles([])
     setPhase(ResizeState.COMPRESSED)
     setProgress(0)
@@ -71,13 +71,7 @@ export const ResizeScreen = () => {
   }
 
   if (phase === ResizeState.COMPRESSING) {
-    return (
-      <div className="compressing">
-        <Loader />
-        <h2>{progress.toFixed(1)}%</h2>
-        <p>Resizing</p>
-      </div>
-    )
+    return (<ProgressLoading progress={progress} />)
   }
 
   return (

--- a/src/screens/ResizeScreen.tsx
+++ b/src/screens/ResizeScreen.tsx
@@ -49,16 +49,15 @@ export const ResizeScreen = () => {
 
   const handleResize = async () => {
     if (imageQuality === 100 && imageSize === 100) return
+    setProgress(0)
     setPhase(ResizeState.COMPRESSING)
     const resizedImages: FileWithBlob[] = await startResize(imageQuality, imageSize)
     setProgress(90)
+    if ( resizedImages.length === 0 ) return setPhase(ResizeState.TO_LOAD)
     setAnchorObjects(getImagesAsAnchor(resizedImages))
     setProgress(100)
-    if ( anchorObjects.length === 0 ) return setPhase(ResizeState.TO_LOAD)
-
     setFiles([])
     setPhase(ResizeState.COMPRESSED)
-    setProgress(0)
   }
 
   const handleOnDownloadAll = () => {

--- a/src/screens/ResizeScreen.tsx
+++ b/src/screens/ResizeScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import DragAndDrop from '../components/DragAndDrop'
 import RangeSlider from '../components/RangeSlider'
 import { ResizeNav } from '../components/ReziseNav'
@@ -7,7 +7,7 @@ import { Loader } from '../components/Loader'
 import { LoadInfo } from '../components/LoadInfo'
 import { SectionContainer } from '../components/SectionContainer'
 import { ResizedImagesList } from '../components/ResizedImagesList'
-import { createDowndloadZip, getFailedImages, getImagesAsAnchor, getSuccessImages } from '../helpers/resizeFiles'
+import { createDowndloadZip, getImagesAsAnchor } from '../helpers/resizeFiles'
 
 import { AnchorObject, ResizeState } from '../types'
 import './ResizeScreen.css'
@@ -16,6 +16,9 @@ export interface FileWithBlob {
   blob: Blob
   name: string
 }
+
+// Importar el Worker
+import ImageWorker from '../webworkers/imageWorker?worker'
 
 export const ResizeScreen = () => {
   const [files, setFiles] = useState<File[]>([])
@@ -26,10 +29,12 @@ export const ResizeScreen = () => {
   const [progress, setProgress] = useState<number>(0)
   const [progressConstant, setProgressConstant] = useState<number>(0)
 
+  const worker = useMemo(() => new ImageWorker(), [])
+
   useEffect(() => {
     if (files.length > 0) {
       setPhase(ResizeState.LOADED)
-      setProgressConstant(Math.floor(80 / files.length))
+      setProgressConstant(80 / files.length)
     }
   }, [files])
 
@@ -37,60 +42,46 @@ export const ResizeScreen = () => {
     if (imageQuality === 100 && imageSize === 100) return
     setPhase(ResizeState.COMPRESSING)
 
-    const resizePromises = files.map((file) => resize(file))
-    const resizedImages = await Promise.allSettled(resizePromises)
+    const resizedImages: FileWithBlob[] = []
+    let completed = 0
 
-    const failedImages = getFailedImages(resizedImages)
+    for (const file of files) {
+      const resizedImage = await resizeImageWithWorker(file, imageQuality, imageSize)
+      if (resizedImage.error) {
+        console.error(`Error resizing image ${file.name}: ${resizedImage.error}`)
+      } else {
+        resizedImages.push(resizedImage)
+      }
+      completed += 1
+      setProgress((prev) => prev + progressConstant)
 
-    if (failedImages.length === files.length) {
-      console.error('All images failed to resize')
-      setPhase(ResizeState.LOADED)
-      return
+      if (completed === files.length) {
+        setProgress(90)
+        setAnchorObjects(getImagesAsAnchor(resizedImages))
+        setProgress(100)
+        setFiles([])
+        setPhase(ResizeState.COMPRESSED)
+        setProgress(0)
+      }
     }
-    setProgress(90)
-    const successImages = getSuccessImages(resizedImages)
-    setAnchorObjects(getImagesAsAnchor(successImages))
-    setProgress(100)
-
-    setFiles([])
-    setPhase(ResizeState.COMPRESSED)
-    setProgress(0)
   }
 
-  const resize = (file: File): Promise<FileWithBlob> => {
-    return new Promise((resolve, reject) => {
-      const image = new Image()
-      image.src = URL.createObjectURL(file)
-      image.onload = () => {
-        const canvas = document.createElement("canvas");
-        const ctx = canvas.getContext("2d");
+  const resizeImageWithWorker = (file: File, imageQuality: number, imageSize: number): Promise<FileWithBlob> => {
+    return new Promise((resolve) => {
+      const { port1, port2 } = new MessageChannel()
 
-        canvas.width = image.naturalWidth * (imageSize / 100)
-        canvas.height = image.naturalHeight * (imageSize / 100)
-        if (ctx) {
-          ctx.drawImage(image, 0, 0, canvas.width, canvas.height)
-          canvas.toBlob((blob) => {
-            if (blob) {
-              resolve({ blob, name: file.name });
-            } else {
-              reject({error: 'Error creating blob', name: file.name})
-            }
-          }, 'image/jpeg', imageQuality / 100);
-        }else{
-          reject({error: 'Error resizing image', name: file.name})
-        }
-        setProgress((prev) => prev + progressConstant)
+      port2.onmessage = (event) => {
+        resolve(event.data)
+        port2.close()
       }
-      image.onerror = () => {
-        reject({error: 'Error loading image', name: file.name})
-      }
+
+      worker.postMessage({ port: port1, file, imageQuality, imageSize }, [port1])
     })
   }
 
   const handleOnDownloadAll = () => {
     createDowndloadZip(anchorObjects, 'resized_images.zip')
   }
-
 
   const handleOnClear = () => {
     setAnchorObjects([])
@@ -101,7 +92,7 @@ export const ResizeScreen = () => {
     return (
       <div className="compressing">
         <Loader />
-        <h2>{progress}%</h2>
+        <h2>{progress.toFixed(1)}%</h2>
         <p>Resizing</p>
       </div>
     )
@@ -111,56 +102,50 @@ export const ResizeScreen = () => {
     <>
       <ResizeNav />
       <main>
-        {
-          (phase === ResizeState.TO_LOAD || phase === ResizeState.LOADED) && (
-            <SectionContainer>
-              <DragAndDrop onFilesSelected={setFiles} files={files} />
-              <LoadInfo filesCount={files.length} onClearFiles={() => setFiles([])} />
-              { files.length > 0 && phase === ResizeState.LOADED && (
-                <>
-                  <div className="upload-settings">
-                    <RangeSlider
-                      label="Image Quality"
-                      min={10}
-                      max={100}
-                      step={10}
-                      initialValue={imageQuality}
-                      onChange={(newValue) => setImageQuality(newValue)}
-                    />
-                    <RangeSlider
-                      label="Image Size"
-                      min={10}
-                      max={100}
-                      step={10}
-                      initialValue={imageSize} onChange={(newValue) => setImageSize(newValue)}
-                    />
-                  </div>
-                  <button className="primary bold large" onClick={handleResize}>
-                    Resize Images
-                  </button>
-                </>
-              )}
-            </SectionContainer>
-          )
-        }
-        {
-          files.length > 0 && phase === ResizeState.LOADED && (
-            <SectionContainer>
-              <FileList files={files} onRemoveFile={(index) => setFiles(files.filter((_, i) => i !== index))} />
-            </SectionContainer>
-          )
-        }
-        {
-          anchorObjects.length > 0 && phase === ResizeState.COMPRESSED && (
-            <SectionContainer>
-              <ResizedImagesList
-                anchorObjects={anchorObjects}
-                onDownloadAll={handleOnDownloadAll}
-                onClear={handleOnClear}
-              />
-            </SectionContainer>
-          )
-        }
+        {(phase === ResizeState.TO_LOAD || phase === ResizeState.LOADED) && (
+          <SectionContainer>
+            <DragAndDrop onFilesSelected={setFiles} files={files} />
+            <LoadInfo filesCount={files.length} onClearFiles={() => setFiles([])} />
+            {files.length > 0 && phase === ResizeState.LOADED && (
+              <>
+                <div className="upload-settings">
+                  <RangeSlider
+                    label="Image Quality"
+                    min={10}
+                    max={100}
+                    step={10}
+                    initialValue={imageQuality}
+                    onChange={(newValue) => setImageQuality(newValue)}
+                  />
+                  <RangeSlider
+                    label="Image Size"
+                    min={10}
+                    max={100}
+                    step={10}
+                    initialValue={imageSize} onChange={(newValue) => setImageSize(newValue)}
+                  />
+                </div>
+                <button className="primary bold large" onClick={handleResize}>
+                  Resize Images
+                </button>
+              </>
+            )}
+          </SectionContainer>
+        )}
+        {files.length > 0 && phase === ResizeState.LOADED && (
+          <SectionContainer>
+            <FileList files={files} onRemoveFile={(index) => setFiles(files.filter((_, i) => i !== index))} />
+          </SectionContainer>
+        )}
+        {anchorObjects.length > 0 && phase === ResizeState.COMPRESSED && (
+          <SectionContainer>
+            <ResizedImagesList
+              anchorObjects={anchorObjects}
+              onDownloadAll={handleOnDownloadAll}
+              onClear={handleOnClear}
+            />
+          </SectionContainer>
+        )}
       </main>
     </>
   )

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,11 @@ export type AnchorObject = {
   blob: Blob
 }
 
+export interface FileWithBlob {
+  blob: Blob
+  name: string
+}
+
 export enum ResizeState {
   TO_LOAD = 'TO_LOAD',
   LOADED = 'LOADED',

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,3 +10,7 @@ export enum ResizeState {
   COMPRESSING = 'COMPRESSING',
   COMPRESSED = 'COMPRESSED',
 }
+
+export type ErrorWithMessage = {
+  error: string
+}

--- a/src/webworkers/imageWorker.ts
+++ b/src/webworkers/imageWorker.ts
@@ -1,4 +1,5 @@
 import { resizeImage } from '../helpers/resizeFiles';
+import { getErrorMessage } from '../helpers/utils';
 
 self.addEventListener('message', async (event) => {
   const { file, imageQuality, imageSize, port } = event.data;
@@ -7,6 +8,7 @@ self.addEventListener('message', async (event) => {
     const resizedImage = await resizeImage(file, imageQuality, imageSize);
     port.postMessage(resizedImage);
   } catch (error) {
-    port.postMessage({ error: error.message });
+    const message = getErrorMessage(error);
+    port.postMessage({ error: message });
   }
 });

--- a/src/webworkers/imageWorker.ts
+++ b/src/webworkers/imageWorker.ts
@@ -1,0 +1,12 @@
+import { resizeImage } from '../helpers/resizeFiles';
+
+self.addEventListener('message', async (event) => {
+  const { file, imageQuality, imageSize, port } = event.data;
+
+  try {
+    const resizedImage = await resizeImage(file, imageQuality, imageSize);
+    port.postMessage(resizedImage);
+  } catch (error) {
+    port.postMessage({ error: error.message });
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
- Create web worker to resize the images in a different thread. This allows to resize a longer bunch of images.
- Change the process of resizing, to use an offscreen canvas instead of an HTML canvas, the reason for this is that, the Image element and the reference of document can not be used in the web worker.
- Separate the logic for resizing to a hook which depends on the worker and the utils functions.
- Separate process to their correspondent components as the progress loader.
